### PR TITLE
Add reference to team topology case study article

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,3 +72,4 @@ Where should the changes go? Choose a subsection that best represents the type o
 ### Examples & Case Studies
 
 * [DataModels-as-a-Service TVP Example](https://github.com/sbalnojan/TVP-example) - Sven Balnojan - ongoing - EN - an example of a TVP using just a wiki page for a data team which provides "DataModels-as-a-Service".
+* [Implementing a team topology](https://4lex.nz/posts/implementing-a-team-topology/) - Alex Corkin - 2021-02-24 - EN - Case study on applying team topologies to a non-tech-at-core business in a New Zealand context


### PR DESCRIPTION
Hi Team,

This PR adds a link under the case study section detailing a New Zealand case study for a business with a separate technology department that was not modelled around streams of value. This is potentially an interesting case study as the cognitive load among these teams was high due to a large legacy architecture that did not lend itself to being split along value streams. 

I am the article author and would be very glad to answer any questions.

Cheers

Alex